### PR TITLE
fix: passwd bcrypt

### DIFF
--- a/apps/auth/utils/managers.py
+++ b/apps/auth/utils/managers.py
@@ -4,6 +4,7 @@ from architecture.manager.backend_manager import AuthManager
 from architecture.manager.base_manager import FrontendManager
 from core.token_generators import LoginTokenGenerator
 
+import bcrypt
 
 class LoginAuthManager(AuthManager):
     token_generator = LoginTokenGenerator
@@ -11,13 +12,21 @@ class LoginAuthManager(AuthManager):
 
 class AppAuthManager(FrontendManager):
 
-    def login(self, email: str, passwd: str) -> str:
+    def login(self, email: str, passwd: str, hashing: bool = True) -> str:
         """
         아이디 패스워드 검증 및 로그인 토큰 발행
         """
+        # 사용자 검색
         user: User = UserCRUDManager().read(user_email=email)
-        if not user or passwd != user.passwd:
-            # 유저가 없거나 패스워드가 틀림
-            raise ValueError('엽력한 정보가 맞지 않습니다.')
+        if not user:
+            # 사용자 없음
+            raise ValueError('해당 사용자는 존재하지 않습니다.')
+        # 패스워드 검토
+        passwd_valid: bool = \
+            bcrypt.checkpw(passwd.encode('utf-8'), user.passwd) if hashing \
+            else passwd == user.passwd
+        if not passwd_valid:
+            # 패스워드 틀림
+            raise ValueError('패스워드가 정확하지 않습니다.')
         # 발급
         return LoginAuthManager().generate_token(req={'email': email})

--- a/apps/share/utils/managers.py
+++ b/apps/share/utils/managers.py
@@ -161,8 +161,13 @@ class DataSharedManager(FrontendManager):
 
         # Admin 권한으로 다운받는다.
         admin_user = UserDBQuery().read(is_admin=True)
+        """
+        Admin 패스워드 상태는 bcrypt로 hashing된 상태이므로
+        패스워드 비교시 추가 해싱 필요 X
+        """
         admin_token = AppAuthManager() \
-            .login(admin_user.email, admin_user.passwd)
+            .login(admin_user.email, admin_user.passwd, hashing=False)
+        # 실제 다운로드 루트 구하기
         download_root = \
             DataManager().read(admin_token, data_info.user_id, shared.datainfo_id, 'download')
         return download_root['file'], data_info.is_dir

--- a/apps/user/tests/test_update.py
+++ b/apps/user/tests/test_update.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
+import bcrypt
 
 from main import app
 from system.bootloader import Bootloader
@@ -182,8 +183,8 @@ def test_change_success(api: TestCase):
     # 변경된 정보 확인
     user_data: User = UserCRUDManager().read(user_email=client_info1['email'])
     assert user_data.name == req['name']
-    assert user_data.passwd == req['passwd']
-    client_info1['passwd'] = user_data.passwd
+    assert bcrypt.checkpw(req['passwd'].encode('utf-8'), user_data.passwd)
+    client_info1['passwd'] = req['passwd']
 
 
 def test_change_only_name_and_client_mine(api: TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,6 @@ Jinja2==3.1.2
 MarkupSafe==2.1.1
 mysqlclient==2.1.0
 packaging==21.3
-pkg_resources==0.0.0
 pluggy==1.0.0
 py==1.11.0
 pycparser==2.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,9 @@ asgiref==3.5.2
 atomicwrites==1.4.0
 attrs==21.4.0
 Automat==20.2.0
+bcrypt==3.2.2
 certifi==2022.5.18.1
+cffi==1.15.1
 charset-normalizer==2.0.12
 click==8.1.3
 codecov==2.1.12
@@ -25,8 +27,10 @@ Jinja2==3.1.2
 MarkupSafe==2.1.1
 mysqlclient==2.1.0
 packaging==21.3
+pkg_resources==0.0.0
 pluggy==1.0.0
 py==1.11.0
+pycparser==2.21
 pydantic==1.9.1
 PyJWT==2.4.0
 pyparsing==3.0.9


### PR DESCRIPTION
패스워드 저장시 bcrypt 암호화 적용
권한이 필요없는 API(공유 데이터 다운로드)인 경우 Admin 권한으로
로그인을 시도해야 하는데 이 때 추출된 패스워드는 암호화 상태이므로
로그인 시도시, 해싱을 하지 않게 해싱 유무 파라미터 추가
(hasing: bool = True)

fix #2